### PR TITLE
Enable project config's content as a YAML document

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <maven-site-plugin.version>3.9.1</maven-site-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.7</nexus-staging-maven-plugin.version>
+        <moshi-plugin.version>1.1.0</moshi-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -120,6 +121,16 @@
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-sdks-java-extensions-protobuf</artifactId>
             <version>${beam.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.ryanharter.auto.value</groupId>
+            <artifactId>auto-value-moshi-runtime</artifactId>
+            <version>${moshi-plugin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>2.12.3</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -205,6 +216,27 @@
                             <artifactId>auto-service</artifactId>
                             <version>${auto-service.version}</version>
                         </path>
+                        <path>
+                            <groupId>com.ryanharter.auto.value</groupId>
+                            <artifactId>auto-value-moshi-extension</artifactId>
+                            <version>${moshi-plugin.version}</version>
+                        </path>
+                        <dependency>
+                            <groupId>com.squareup</groupId>
+                            <artifactId>javapoet</artifactId>
+                            <version>1.12.0</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>com.squareup.moshi</groupId>
+                            <artifactId>moshi</artifactId>
+                            <version>1.9.2</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>io.sweers.autotransient</groupId>
+                            <artifactId>autotransient</artifactId>
+                            <version>1.0.0</version>
+                        </dependency>
+
                     </annotationProcessorPaths>
                 </configuration>
                 <executions>
@@ -230,8 +262,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
-                    <skipTests>true</skipTests>
-                    <!--<excludedGroups>RemoteCDP, RemoteCDF</excludedGroups>-->
+                    <skipTests>false</skipTests>
+                    <excludedGroups>remoteCDP, remoteCDF</excludedGroups>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/cognite/beam/io/config/GcpSecretConfig.java
+++ b/src/main/java/com/cognite/beam/io/config/GcpSecretConfig.java
@@ -17,6 +17,7 @@
 package com.cognite.beam.io.config;
 
 import com.google.auto.value.AutoValue;
+import com.squareup.moshi.JsonClass;
 import org.apache.beam.sdk.coders.DefaultCoder;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.options.ValueProvider;
@@ -32,6 +33,7 @@ import static com.google.common.base.Preconditions.*;
  */
 @AutoValue
 @DefaultCoder(SerializableCoder.class)
+@JsonClass(generateAdapter = true, generator = "avm")
 public abstract class GcpSecretConfig implements Serializable {
     private final static String DEFAULT_SECRET_VERSION = "latest";
 

--- a/src/main/java/com/cognite/beam/io/config/ValueProviderAdapter.java
+++ b/src/main/java/com/cognite/beam/io/config/ValueProviderAdapter.java
@@ -1,0 +1,17 @@
+package com.cognite.beam.io.config;
+
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.ToJson;
+import org.apache.beam.sdk.options.ValueProvider;
+
+public class ValueProviderAdapter {
+    @FromJson
+    ValueProvider<String> fromJson(String value) {
+        return ValueProvider.StaticValueProvider.of(value);
+    }
+
+    @ToJson
+    String eventToJson(ValueProvider<String> value) {
+        return value.get();
+    }
+}

--- a/src/test/java/com/cognite/beam/io/config/ProjectConfigTest.java
+++ b/src/test/java/com/cognite/beam/io/config/ProjectConfigTest.java
@@ -1,0 +1,48 @@
+package com.cognite.beam.io.config;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ProjectConfigTest {
+
+    @Test
+    public void testTrivialYaml() {
+        String _yaml = "host: blah\nconfigured: true";
+        ProjectConfig config = ProjectConfig.create().withYaml(_yaml);
+        assertNotNull(config);
+        assertTrue(config.isConfigured());
+        assertEquals(config.getHost().get(), "blah");
+    }
+
+    @Test
+    public void basicYaml() throws IOException {
+        String _yaml = Files.readString(Path.of("./src/test/resources/basic-project-config.yaml"));
+        ProjectConfig config = ProjectConfig.create().withYaml(_yaml);
+        assertNotNull(config);
+        assertTrue(config.isConfigured());
+        assertEquals(config.getHost().get(), "https://api.cognitedata.com");
+        assertEquals(config.getApiKey().get(), "something");
+    }
+
+    @Test
+    public void completeYaml() throws IOException {
+        String _yaml = Files.readString(Path.of("./src/test/resources/complete-project-config.yaml"));
+        ProjectConfig config = ProjectConfig.create().withYaml(_yaml);
+        assertNotNull(config);
+        assertTrue(config.isConfigured());
+        assertEquals(config.getHost().get(), "https://api.cognitedata.com");
+        assertNull(config.getApiKey());
+        assertEquals(Objects.requireNonNull(config.getClientId()).get(), "boo");
+        assertEquals(Objects.requireNonNull(config.getClientSecret()).get(), "foo");
+        assertNotNull(config.getClientSecretGcpSecretConfig());
+        assertEquals(config.getClientSecretGcpSecretConfig().getProjectId().get(), "test-project");
+        assertEquals(config.getClientSecretGcpSecretConfig().getSecretId().get(), "secret-name");
+        assertEquals(config.getClientSecretGcpSecretConfig().getSecretVersion().get(), "latest");
+    }
+}

--- a/src/test/resources/basic-project-config.yaml
+++ b/src/test/resources/basic-project-config.yaml
@@ -1,0 +1,4 @@
+project: test-project
+host: https://api.cognitedata.com
+apiKey: something
+configured: true

--- a/src/test/resources/complete-project-config.yaml
+++ b/src/test/resources/complete-project-config.yaml
@@ -1,0 +1,10 @@
+project: test-project
+host: https://api.cognitedata.com
+clientId: boo
+clientSecret: foo
+tokenUrl: https://google.com
+configured: true
+clientSecretGcpSecretConfig:
+  projectId: test-project
+  secretId: secret-name
+  secretVersion: latest


### PR DESCRIPTION
Idea behind this change is the following: 
1. All Beam pipelines (when provision/deploy) execute `run` locally.
2. `gcloud dataflow flex-template run` does execute locally (we will be able to mount secret as a file within k8s pod)
3.   We can resolve k8s secret into the plain file within pod and won't need pipeline itself to access Secret manager