### PR TITLE
Updated documentation that I was really wondering about

### DIFF
--- a/src/main/java/com/cognite/beam/io/RequestParameters.java
+++ b/src/main/java/com/cognite/beam/io/RequestParameters.java
@@ -222,6 +222,7 @@ public abstract class RequestParameters implements Serializable {
 
     /**
      * Adds a new parameter to the filter node.
+     * See the request samples of the <a href="https://docs.cognite.com/api/v1/">official documentation</a> for valid filters.
      *
      * @param key
      * @param value


### PR DESCRIPTION
Some user of this SDK will probably wonder the same as me at some point - "What are valid filters".

This all stems from a misunderstanding on my side, using the `withPollOffset` method. 
What I expected the behaviour of this to be was: 
`withPollOffset(Duration.ofHours(2))` -> We don't read events that are less than two hours old since creation

Clearly, my understanding of the behaviour is lacking. Perhaps you can clarify what the material difference between 
``` java
 long maxCreatedTimeForEvents = System.currentTimeMillis() - Duration.ofHours(2).toMillis();
// Working as I expect
.withFilterParameter("createdTime", ImmutableMap.of("max", maxCreatedTimeForEvents))
```
and 
``` java
// Not working as I expect
.withPollOffset(Duration.ofHours(2))
```
is to me?
