### PR TITLE
Do not emit empty batches in read direct mode.

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -25,6 +25,12 @@ Changes are grouped as follows:
 - OOTB incremental read support for time series.
 - Geo-location attribute and resource type.
 
+## [0.9.31-SNAPSHOT]
+
+### Fixed
+
+- `Read direct` could emit empty batches in certain circumstances. 
+
 ## [0.9.30] 2021-11-14
 
 ### Added
@@ -39,7 +45,6 @@ when you have pre-batched objects. This can offer improved performance when writ
 
 - File binary upload robustness (Java SDK v1.5.0).
 - `Labels` using api v1 endpoint (Java SDK v1.5.0).
-
 
 ## [0.9.29] 2021-11-09
 

--- a/src/main/java/com/cognite/beam/io/fn/read/ListItemsBatchBaseFn.java
+++ b/src/main/java/com/cognite/beam/io/fn/read/ListItemsBatchBaseFn.java
@@ -95,17 +95,19 @@ public abstract class ListItemsBatchBaseFn<T> extends IOBaseFn<RequestParameters
                     apiBatchSize.update(results.size());
                     apiLatency.update(Duration.between(pageStartInstant, Instant.now()).toMillis());
                 }
-                if (readerConfig.isStreamingEnabled()) {
-                    // output with timestamps in streaming mode--need that for windowing
-                    long minTimestampMs = results.stream()
-                            .mapToLong(item -> getTimestamp(item))
-                            .min()
-                            .orElse(1L);
+                if (results.size() > 0) {
+                    if (readerConfig.isStreamingEnabled()) {
+                        // output with timestamps in streaming mode--need that for windowing
+                        long minTimestampMs = results.stream()
+                                .mapToLong(item -> getTimestamp(item))
+                                .min()
+                                .orElse(1L);
 
-                     outputReceiver.outputWithTimestamp(results, org.joda.time.Instant.ofEpochMilli(minTimestampMs));
-                } else {
-                    // no timestamping in batch mode--just leads to lots of complications
-                    outputReceiver.output(results);
+                        outputReceiver.outputWithTimestamp(results, org.joda.time.Instant.ofEpochMilli(minTimestampMs));
+                    } else {
+                        // no timestamping in batch mode--just leads to lots of complications
+                        outputReceiver.output(results);
+                    }
                 }
 
                 totalNoItems += results.size();


### PR DESCRIPTION
Check that a results batch is non-empty before emitting it. 